### PR TITLE
Fixed Ragnaros and Onyxia loot tables for patch <= 1.3

### DIFF
--- a/sql/1.02/1.02_loot.sql
+++ b/sql/1.02/1.02_loot.sql
@@ -55,6 +55,7 @@ update creature_loot_template set ChanceOrQuestChance=30 where mincountOrRef=-32
 
 update creature_loot_template set maxcount=1,chanceorquestchance=0 where mincountOrRef=-330001;
 delete from reference_loot_template where entry = 936302 and item = 19137;
+update creature_loot_template set ChanceOrQuestChance = 0 where entry = 11502 and item = 17204;
 
 -- Onyxia loot table
 

--- a/sql/1.02/1.02_loot.sql
+++ b/sql/1.02/1.02_loot.sql
@@ -47,24 +47,22 @@ delete from reference_loot_template where item=17077 and entry in (326586,326299
 
 delete from gameobject_loot_template where item=18703 and entry=16719;
 
--- Ragnaros
-
-update creature_loot_template set ChanceOrQuestChance=15 where mincountOrRef=-330001;
-replace into reference_loot_template value (322538, 17067, 0, 3, 1, 1, 0);
-update creature_loot_template set ChanceOrQuestChance=0 where mincountOrRef=-322539;
-update creature_loot_template set ChanceOrQuestChance=25 where mincountOrRef=-322538;
-
 -- Garr
 
 update creature_loot_template set ChanceOrQuestChance=30 where mincountOrRef=-326264;
 
 -- Ragnaros
 
-update creature_loot_template set maxcount=1,chanceorquestchance=100 where mincountOrRef=-330001;
+update creature_loot_template set maxcount=1,chanceorquestchance=0 where mincountOrRef=-330001;
+delete from reference_loot_template where entry = 936302 and item = 19137;
 
 -- Onyxia loot table
 
 update creature_loot_template set ChanceOrQuestChance=100 where mincountOrRef=-322538 and entry=10184;
+update creature_loot_template set ChanceOrQuestChance=100 where mincountOrRef = -322539 and entry = 10184;
+delete from reference_loot_template where entry = 322539 and item in (18205, 18813);
+    --  Head and sinew
+update creature_loot_template set ChanceOrQuestChance=0 where entry = 10184 and item in (18422, 18423, 18705);
 
 -- Zul'farrak pre-1.04 fix
 

--- a/sql/1.03/1.03_loot.sql
+++ b/sql/1.03/1.03_loot.sql
@@ -171,13 +171,14 @@ update creature_loot_template set ChanceOrQuestChance=30 where mincountOrRef=-32
 
 update creature_loot_template set maxcount=1,chanceorquestchance=0 where mincountOrRef=-330001;
 delete from reference_loot_template where entry = 936302 and item = 19137;
+update creature_loot_template set ChanceOrQuestChance = 0 where entry = 11502 and item = 17204;
 
 -- Onyxia loot table
 
 update creature_loot_template set ChanceOrQuestChance=100 where mincountOrRef=-322538 and entry=10184;
 update creature_loot_template set ChanceOrQuestChance=100 where mincountOrRef = -322539 and entry = 10184;
 delete from reference_loot_template where entry = 322539 and item in (18205, 18813);
-    --  Head and sinew
+--  Head and sinew
 update creature_loot_template set ChanceOrQuestChance=0 where entry = 10184 and item in (18422, 18423, 18705);
 
 -- Zul'farrak pre-1.04 fix

--- a/sql/1.03/1.03_loot.sql
+++ b/sql/1.03/1.03_loot.sql
@@ -163,24 +163,22 @@ delete from reference_loot_template where item=17077 and entry in (326586,326299
 
 delete from gameobject_loot_template where item=18703 and entry=16719;
 
--- Ragnaros
-
-update creature_loot_template set ChanceOrQuestChance=15 where mincountOrRef=-330001;
-replace into reference_loot_template value (322538, 17067, 0, 3, 1, 1, 0);
-update creature_loot_template set ChanceOrQuestChance=0 where mincountOrRef=-322539;
-update creature_loot_template set ChanceOrQuestChance=25 where mincountOrRef=-322538;
-
 -- Garr
 
 update creature_loot_template set ChanceOrQuestChance=30 where mincountOrRef=-326264;
 
 -- Ragnaros
 
-update creature_loot_template set maxcount=1,chanceorquestchance=100 where mincountOrRef=-330001;
+update creature_loot_template set maxcount=1,chanceorquestchance=0 where mincountOrRef=-330001;
+delete from reference_loot_template where entry = 936302 and item = 19137;
 
 -- Onyxia loot table
 
 update creature_loot_template set ChanceOrQuestChance=100 where mincountOrRef=-322538 and entry=10184;
+update creature_loot_template set ChanceOrQuestChance=100 where mincountOrRef = -322539 and entry = 10184;
+delete from reference_loot_template where entry = 322539 and item in (18205, 18813);
+    --  Head and sinew
+update creature_loot_template set ChanceOrQuestChance=0 where entry = 10184 and item in (18422, 18423, 18705);
 
 -- Zul'farrak pre-1.04 fix
 


### PR DESCRIPTION
This fixes loot drops for Onyxia and Ragnaros when using 1.3 itemization. I'm not sure what Elysium and Zeth'Kur are currently running on, since Ragnaros would be dropping 1.5 items if it were using the current version, but this patch will fix it regardless.

Perhaps the biggest change is the fix to Onyxia's loot tables. Currently on Elysium and Zeth'Kur, Onyxia only has a single pool, of which Ancient Cornerstone Grimoire (item ID 17067) has a 74% drop rate; which is grossly wrong. The droprate is the result of this line: `replace into reference_loot_template value (322538, 17067, 0, 3, 1, 1, 0);` (adding to the first pool) and the subsequent disabling of the second pool. In contrast to ACG's high drop rate, disabling the second pool results in Sapphiron Drape being unobtainable. 

Ragnaros' SQL statements for some reason altered Onyxia's pools as well (???). This patch removes the items that should not be in the second pool, and keeps both pools enabled, as they should be. It also disables the pool which should not exist yet for Ragnaros, and removes 1.5 items from the pools which do. Furthermore, it disables the Head and Sinew drops for Onyxia (which are already unavailable on Ely/Zeth, which is why I am puzzled as to what is actually in use).

The items present are in accordance with https://web.archive.org/web/20050406002012/http://wow.allakhazam.com:80/db/mob.html?wmob=10184 (April, 2015 - 1 month before 1.5 landed). The droprates on the book/cape might be slightly higher than they were in retail, but there is no concrete evidence and I believe a little leeway should be given considering how long the pools have been broken (release).

If it is unfeasible to apply these patches to Ely/Zeth again before 1.5 is released, at the very least it would be ideal for Onyxia's table to be fixed, with pool 322539 enabled (with items 18205 and 18813 removed)  and ACG removed from pool 322538.